### PR TITLE
Add `-Revert` argument and colorize light mode Windows Spotlight glyphs on 22H2 properly

### DIFF
--- a/AccentColorizer-E11/GlyphColorizer.cs
+++ b/AccentColorizer-E11/GlyphColorizer.cs
@@ -22,16 +22,26 @@ namespace AccentColorizer_E11
 
         public void ApplyColorization()
         {
-            ColorizeGlyphs("light", AccentColors.GetColorByTypeName("ImmersiveSystemAccent"), DEFAULT_COLOR_LIGHT);
-            ColorizeGlyphs("dark", AccentColors.GetColorByTypeName("ImmersiveSystemAccentLight2"), DEFAULT_COLOR_DARK);
+            string ImmersiveSystemAccent = Utility.ColorToHex(AccentColors.GetColorByTypeName("ImmersiveSystemAccent"));
+            string ImmersiveSystemAccentLight2 = Utility.ColorToHex(AccentColors.GetColorByTypeName("ImmersiveSystemAccentLight2"));
+
+            ColorizeGlyphs("light", ImmersiveSystemAccent, DEFAULT_COLOR_LIGHT);
+            ColorizeGlyphs("dark", ImmersiveSystemAccentLight2, DEFAULT_COLOR_DARK);
         }
 
-        public void ColorizeGlyphs(string theme, Color replacementColor, string defaultColor)
+        public void RevertColorization()
         {
-            var color = Utility.ColorToHex(replacementColor);
+            string ImmersiveSystemAccent = Utility.ColorToHex(AccentColors.GetColorByTypeName("ImmersiveSystemAccent"));
+            string ImmersiveSystemAccentLight2 = Utility.ColorToHex(AccentColors.GetColorByTypeName("ImmersiveSystemAccentLight2"));
 
+            ColorizeGlyphs("light", DEFAULT_COLOR_LIGHT, ImmersiveSystemAccent);
+            ColorizeGlyphs("dark", DEFAULT_COLOR_DARK, ImmersiveSystemAccentLight2);
+        }
+
+        public void ColorizeGlyphs(string theme, string replacementColor, string defaultColor)
+        {
             var currentColor = (string)key.GetValue(theme, defaultColor);
-            key.SetValue(theme, color);
+            key.SetValue(theme, replacementColor);
 
             foreach (var basePath in paths)
             {
@@ -42,11 +52,12 @@ namespace AccentColorizer_E11
                     var path = file.FullName;
 
                     var raw = Utility.ReadFile(path);
-                    raw = raw.Replace(currentColor, color).Replace(defaultColor, color);
+                    raw = raw.Replace(currentColor, replacementColor).Replace(defaultColor, replacementColor);
+                    
                     if ("light".Equals(theme))
                     {
                         // Windows Spotlight has a different color used (WHY?)
-                        raw = raw.Replace("#0C59A4", color);
+                        raw = raw.Replace("#0C59A4", replacementColor);
                     }
 
                     try

--- a/AccentColorizer-E11/GlyphColorizer.cs
+++ b/AccentColorizer-E11/GlyphColorizer.cs
@@ -1,8 +1,6 @@
 ﻿using Microsoft.Win32;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Windows.Media;
 
 namespace AccentColorizer_E11
 {

--- a/AccentColorizer-E11/GlyphColorizer.cs
+++ b/AccentColorizer-E11/GlyphColorizer.cs
@@ -41,6 +41,9 @@ namespace AccentColorizer_E11
             var currentColor = (string)key.GetValue(theme, defaultColor);
             key.SetValue(theme, replacementColor);
 
+            var currentColorSpotlight = Utility.BlendColors("#251840", currentColor, 82);
+            var replacementColorSpotlight = Utility.BlendColors("#251840", replacementColor, 82);
+
             foreach (var basePath in paths)
             {
                 var dir = new DirectoryInfo(basePath + theme);
@@ -51,11 +54,11 @@ namespace AccentColorizer_E11
 
                     var raw = Utility.ReadFile(path);
                     raw = raw.Replace(currentColor, replacementColor).Replace(defaultColor, replacementColor);
-                    
+
                     if ("light".Equals(theme))
                     {
                         // Windows Spotlight has a different color used (WHY?)
-                        raw = raw.Replace("#0C59A4", replacementColor);
+                        raw = raw.Replace(currentColorSpotlight, replacementColorSpotlight).Replace("#0C59A4", replacementColorSpotlight);
                     }
 
                     try

--- a/AccentColorizer-E11/Program.cs
+++ b/AccentColorizer-E11/Program.cs
@@ -10,6 +10,7 @@ namespace AccentColorizer_E11
     class Program
     {
         public const string ARGUMENT_APPLY = "-" + "Apply";
+        public const string ARGUMENT_REVERT = "-" + "Revert";
         public const string ARGUMENT_TAKEOWN = "-" + "TakeOwnership";
 
         public const string LISTENER_MUTEX = "-" + "ACCENTCLRE11";
@@ -47,9 +48,15 @@ namespace AccentColorizer_E11
                 colorizer.ApplyColorization();
                 key.Close();
             }
+            else if ((args.Length == 1 && ARGUMENT_REVERT.Equals(args[0])) || (args.Length == 2 && ARGUMENT_REVERT.Equals(args[1])))
+            {
+                colorizer.RevertColorization();
+                key.Close();
+            }
             else
             {
                 Mutex mutex;
+
                 if (Mutex.TryOpenExisting(LISTENER_MUTEX, out mutex))
                 {
                     key.Close();

--- a/AccentColorizer-E11/Utility.cs
+++ b/AccentColorizer-E11/Utility.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Win32;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Security.AccessControl;
@@ -34,6 +35,23 @@ namespace AccentColorizer_E11
         public static string ColorToHex(Color c)
         {
             return "#" + c.R.ToString("X2") + c.G.ToString("X2") + c.B.ToString("X2");
+        }
+
+        public static string BlendColors(string color1, string color2, int intensity)
+        {
+            int color1_R = Convert.ToInt32($"{color1[1]}{color1[2]}", 16);
+            int color1_G = Convert.ToInt32($"{color1[3]}{color1[4]}", 16);
+            int color1_B = Convert.ToInt32($"{color1[5]}{color1[6]}", 16);
+
+            int color2_R = Convert.ToInt32($"{color2[1]}{color2[2]}", 16);
+            int color2_G = Convert.ToInt32($"{color2[3]}{color2[4]}", 16);
+            int color2_B = Convert.ToInt32($"{color2[5]}{color2[6]}", 16);
+
+            int R = (int)Math.Round((((color1_R * intensity)) + (color2_R * (255 - intensity))) / 255.0);
+            int G = (int)Math.Round((((color1_G * intensity)) + (color2_G * (255 - intensity))) / 255.0);
+            int B = (int)Math.Round((((color1_B * intensity)) + (color2_B * (255 - intensity))) / 255.0);
+
+            return $"#{R:X2}{G:X2}{B:X2}";
         }
 
         public static string ReadFile(string filepath)

--- a/README.md
+++ b/README.md
@@ -5,8 +5,15 @@ Colorize Windows 11 File Explorer Icon Glyphs with accent color
 Part of the [AccentColorizer](https://github.com/krlvm/AccentColorizer) project
 
 The program will run in background and recolorize the glyphs every time accent color is changed, but if you need to run it once and don't want to have it running in background, launch it with `-Apply` argument:
-```
+
+```powershell
 $ AccentColorizer-E11.exe -Apply
+```
+
+If you want to revert the changes made by this program, make sure it is not running in the background and then launch it using the `-Revert` argument:
+
+```powershell
+$ AccentColorizer-E11.exe -Revert
 ```
 
 ## Gallery


### PR DESCRIPTION
This PR adds a `-Revert` argument to AC-E11. When the program is running with that argument, it will revert the glyphs' accent color back to the original color (blue) without the need to temporarily change the accent color back to blue, run the program (if it's not running), wait for the glyphs to get colorized, kill the program from Task Manager and then change the accent color back to the one you initially had, making the process of undoing changes much easier. The PR also adds some info in the README.md file about the `-Revert` argument and how to run the tool using it.

It also adds proper colorization for light mode Spotlight-related glyphs on 22H2. Here are some screenshots:

<img src="https://github.com/user-attachments/assets/91619aff-e720-4a8c-8a58-a0a04de87a8b" /><br>
<img src="https://github.com/user-attachments/assets/4db2edb7-7a5f-4377-b95c-1d8c34e9bb53" /><br>
<img src="https://github.com/user-attachments/assets/9e6c9963-6f98-4750-b543-9335cbf591a9" /><br>
